### PR TITLE
Add per-environment labeling and timestamped export files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python compare_prompt_results.py input.csv output.xlsx
 streamlit run streamlit_app.py
 ```
 
-Upload a CSV file with results to generate an interactive comparison and download an Excel report.
+Upload a CSV file with results to generate an interactive comparison and download an Excel report. Each NPR and Sandbox output can be individually labelled as *Correct*, *Acceptable*, or *Wrong*, and exported reports are saved with a timestamped filename.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Allow separate NPR and Sandbox labels (Correct/Acceptable/Wrong) with optional acceptable reasons
- Prefix exported report filenames with current timestamp
- Document new labeling and timestamped export features

## Testing
- `python -m py_compile streamlit_app.py compare_prompt_results.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894445931e4832193aadfa1b6be4d1e