### PR TITLE
feat: add side-by-side json diff viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains tools for comparing GPT extraction results between two 
 ## Components
 
 - **compare_prompt_results.py** – CLI tool that reads a CSV containing results for multiple prompts and compares the outputs between the "NPR" and "Sandbox" environments. It writes an Excel report summarising the differences.
-- **streamlit_app.py** – Streamlit web application for interactively exploring comparison results.
+- **streamlit_app.py** – Streamlit web application for interactively exploring comparison results, including a side-by-side JSON diff viewer.
 
 ## Installation
 
@@ -28,6 +28,7 @@ streamlit run streamlit_app.py
 ```
 
 Upload a CSV file with results to generate an interactive comparison and download an Excel report. Each NPR and Sandbox output can be individually labelled as *Correct*, *Acceptable*, or *Wrong*, and exported reports are saved with a timestamped filename.
+The app also provides a side-by-side viewer that highlights JSON differences between environments.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `show_json_diff` helper using Python's `difflib` to render side-by-side JSON comparisons with inline highlighting
- display formatted JSON for NPR and Sandbox and integrate the diff viewer into the Streamlit workflow
- document new JSON diff capabilities in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68944f60a1a8832192801eb035984a9e