### PR TITLE
Add next/first navigation buttons for cases and prompts

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -61,10 +61,40 @@ def main() -> None:
         comp_df["casenumber"].astype(str)
         + " | "
         + comp_df["attachment_name"].astype(str)
+    ).tolist()
+    if "case_idx" not in st.session_state:
+        st.session_state["case_idx"] = 0
+    if "prompt_idx" not in st.session_state:
+        st.session_state["prompt_idx"] = 0
+
+    case_sel, next_case, first_case = st.columns([3, 1, 1])
+    selected_case = case_sel.selectbox(
+        "Case / Attachment", case_options, index=st.session_state["case_idx"]
     )
-    selected_case = st.selectbox("Case / Attachment", case_options)
+    if next_case.button("Next Case"):
+        st.session_state["case_idx"] = (
+            st.session_state["case_idx"] + 1
+        ) % len(case_options)
+        st.experimental_rerun()
+    if first_case.button("First Case"):
+        st.session_state["case_idx"] = 0
+        st.experimental_rerun()
+    st.session_state["case_idx"] = case_options.index(selected_case)
     case_num, attach_name = selected_case.split(" | ")
-    prompt = st.selectbox("Prompt", PROMPT_COLUMNS)
+
+    prompt_sel, next_prompt, first_prompt = st.columns([3, 1, 1])
+    prompt = prompt_sel.selectbox(
+        "Prompt", PROMPT_COLUMNS, index=st.session_state["prompt_idx"]
+    )
+    if next_prompt.button("Next Prompt"):
+        st.session_state["prompt_idx"] = (
+            st.session_state["prompt_idx"] + 1
+        ) % len(PROMPT_COLUMNS)
+        st.experimental_rerun()
+    if first_prompt.button("First Prompt"):
+        st.session_state["prompt_idx"] = 0
+        st.experimental_rerun()
+    st.session_state["prompt_idx"] = PROMPT_COLUMNS.index(prompt)
 
     npr_row = df[
         (df["casenumber"].astype(str) == case_num)


### PR DESCRIPTION
## Summary
- add navigation buttons next and first to case/attachment and prompt selectors
- store selection state and rerun app when navigating
- convert case options to a list to avoid RangeIndex errors when tracking selection

## Testing
- `python -m py_compile streamlit_app.py compare_prompt_results.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946923cadc83219a18da5fa97d4a57