### PR TITLE
Synchronize labels across all categories when texts match

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -144,10 +144,12 @@ def main() -> None:
 
     # Sync labels before widgets are created to avoid modifying widget state after instantiation
     if npr_text == sandbox_text:
-        if st.session_state.get(npr_key) == "Correct":
-            st.session_state[sandbox_key] = "Correct"
-        elif st.session_state.get(sandbox_key) == "Correct":
-            st.session_state[npr_key] = "Correct"
+        npr_state = st.session_state.get(npr_key)
+        sandbox_state = st.session_state.get(sandbox_key)
+        if npr_state in label_options[1:]:
+            st.session_state[sandbox_key] = npr_state
+        elif sandbox_state in label_options[1:]:
+            st.session_state[npr_key] = sandbox_state
 
     # Determine currently selected labels
     npr_selected = st.session_state.get(npr_key, validation.get("npr_label", ""))


### PR DESCRIPTION
## Summary
- Ensure Streamlit app synchronizes labels for NPR and Sandbox when their texts are identical, regardless of whether the chosen label is Correct, Acceptable, or Wrong

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894aab500f88321903914b78b7212cd